### PR TITLE
Update prometheus buckets

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -73,7 +73,7 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 			Subsystem: subsystem,
 			Name:      "request_duration_seconds",
 			Help:      "Histogram request latencies",
-			Buckets:   []float64{.005, .01, .02, 0.04, .06, 0.08, .1, 0.15, .25, 0.4, .6, .8, 1, 1.5, 2, 3, 5},
+			Buckets:   []float64{0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7, 10, 15, 20},
 		},
 		[]string{"code", "path"},
 	)


### PR DESCRIPTION
Update to 0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7, 10, 15, 20 to better capture slow requests up to 15-20 seconds while focusing on the typical range
0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7, 10, 15, 20

Why This Range?

Starts at 0.1s: our mean response times (285-548 ms) suggest most requests are above 0.1s, so smaller buckets like 0.005s are likely underutilized.
Fine-grained up to 1s: Buckets like 0.1, 0.2, 0.3, 0.5, 0.75, 1 provide good granularity where most requests fall.
Wider spacing for slower requests: 1.5, 2, 3, 5, 7, 10, 15, 20 capture the tail, ensuring requests up to 15s (or even 20s) are tracked explicitly.
Total Buckets: 14, reducing metric cardinality.