### PR TITLE
remove 7, 10, 15, 20 from prom bucket

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -73,7 +73,7 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 			Subsystem: subsystem,
 			Name:      "request_duration_seconds",
 			Help:      "Histogram request latencies",
-			Buckets:   []float64{0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7, 10, 15, 20},
+			Buckets:   []float64{0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5},
 		},
 		[]string{"code", "path"},
 	)


### PR DESCRIPTION
Dove had issues after releasing ref https://carousell.slack.com/archives/C017WSWDT6X/p1748921073511149. based ashraful's comment https://carousell.slack.com/archives/C01F7H2DV1D/p1748949372329709?thread_ts=1748941898.905969&cid=C01F7H2DV1D i'm reducing the bucket.

dove is correct now https://carousell.slack.com/archives/C017WSWDT6X/p1753098352787529?thread_ts=1748921073.511149&cid=C017WSWDT6X